### PR TITLE
Build an image with Sphinx v3.1.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 FROM bitnami/minideb:stretch
 
 # https://sphinxsearch.com/blog/
-ENV SPHINX_VERSION 3.0.3-facc3fb
+ENV SPHINX_VERSION 3.1.1-612d99f
 
 # install dependencies
 RUN apt-get update && apt-get install -y \
@@ -21,7 +21,7 @@ RUN cd /opt/sphinx && tar -xf /tmp/sphinxsearch.tar.gz
 RUN rm /tmp/sphinxsearch.tar.gz
 
 # point to sphinx binaries
-ENV PATH "${PATH}:/opt/sphinx/sphinx-3.0.3/bin"
+ENV PATH "${PATH}:/opt/sphinx/sphinx-3.1.1/bin"
 RUN indexer -v
 
 # redirect logs to stdout

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,21 @@
 # Dockerfile for Sphinx SE
-# https://hub.docker.com/r/bitnami/minideb
-FROM bitnami/minideb:stretch
+# https://hub.docker.com/_/alpine/
+FROM alpine:3.8
 
 # https://sphinxsearch.com/blog/
 ENV SPHINX_VERSION 3.1.1-612d99f
 
 # install dependencies
-RUN apt-get update && apt-get install -y \
-	default-libmysqlclient-dev \
-	libpq-dev \
+RUN apk add --no-cache mariadb-connector-c-dev \
+	postgresql-dev \
 	wget
 
 # set up and expose directories
 RUN mkdir -pv /opt/sphinx/log /opt/sphinx/index
 VOLUME /opt/sphinx/index
 
-# http://sphinxsearch.com/files/sphinx-3.0.3-facc3fb-linux-amd64.tar.gz
-RUN wget http://sphinxsearch.com/files/sphinx-${SPHINX_VERSION}-linux-amd64.tar.gz -O /tmp/sphinxsearch.tar.gz
+# http://sphinxsearch.com/files/sphinx-3.1.1-612d99f-linux-amd64-musl.tar.gz
+RUN wget http://sphinxsearch.com/files/sphinx-${SPHINX_VERSION}-linux-amd64-musl.tar.gz -O /tmp/sphinxsearch.tar.gz
 RUN cd /opt/sphinx && tar -xf /tmp/sphinxsearch.tar.gz
 RUN rm /tmp/sphinxsearch.tar.gz
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # docker-sphinxsearch
-Docker image for Sphinx search engine
-
-[Read more](https://hub.docker.com/r/macbre/sphinxsearch/)
+Docker image for [Sphinx search engine](http://sphinxsearch.com/docs/sphinx3.html)
 
 ```
 docker pull macbre/sphinxsearch

--- a/README.md
+++ b/README.md
@@ -25,7 +25,23 @@ services:
 
 ## [Tags available](https://hub.docker.com/r/macbre/sphinxsearch/tags/)
 
-### `3.0.3`, `latest`
+### `3.1.1`, `latest`
+
+```
+Sphinx 3.1.1 (commit 612d99f4)
+Copyright (c) 2001-2018, Andrew Aksyonoff
+Copyright (c) 2008-2016, Sphinx Technologies Inc (http://sphinxsearch.com)
+
+Built on: Linux alpine38 4.14.69-0-vanilla #1-Alpine SMP Mon Sep 10 19:33:23 UTC 2018 x86_64 Linux
+Built with: gcc 6.4.0
+Build date: Oct 17 2018
+Build type: release
+Configure flags:  '--enable-dl' '--with-mysql' '--with-pgsql' '--with-unixodbc' 'CXXFLAGS=-DSPHINX_TAG= -DNDEBUG -O3 -g1 -D__MUSL__' 'LDFLAGS=-static-libstdc++ -static-libgcc'
+Compiled DB drivers: mysql-dynamic pgsql-dynamic odbc-dynamic
+Enabled dynamic drivers: mysql pgsql
+```
+
+### `3.0.3`
 
 ```
 Sphinx 3.0.3 (commit facc3fb)


### PR DESCRIPTION
http://sphinxsearch.com/blog/2018/10/17/sphinx-3-1-1-released/

[Sphinx now provides MUSL binaries for Alpine](http://sphinxsearch.com/downloads/current/), let's use them and decrease the image size from 205 to 134 MB (**35% smaller**).