### PR TITLE
Sphinx 3.8.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # Dockerfile for Sphinx SE
 # https://hub.docker.com/_/alpine/
-FROM --platform=linux/amd64 alpine:3.19
+FROM --platform=linux/amd64 alpine:3.21
 
 # https://sphinxsearch.com/blog/
-ENV SPHINX_VERSION 3.7.1-da9f8a4
+ENV SPHINX_VERSION 3.8.1-d25e0bb
 
 # install dependencies
 RUN apk add --no-cache mariadb-connector-c-dev \
@@ -14,13 +14,13 @@ RUN apk add --no-cache mariadb-connector-c-dev \
 RUN mkdir -pv /opt/sphinx/logs /opt/sphinx/indexes
 VOLUME /opt/sphinx/indexes
 
-# https://sphinxsearch.com/files/sphinx-3.7.1-da9f8a4-linux-amd64-musl.tar.gz
+# https://sphinxsearch.com/files/sphinx-3.8.1-d25e0bb-linux-amd64-musl.tar.gz
 RUN wget http://sphinxsearch.com/files/sphinx-${SPHINX_VERSION}-linux-amd64-musl.tar.gz -O /tmp/sphinxsearch.tar.gz \
 	&& cd /opt/sphinx && tar -xf /tmp/sphinxsearch.tar.gz \
 	&& rm /tmp/sphinxsearch.tar.gz
 
 # point to sphinx binaries
-ENV PATH "${PATH}:/opt/sphinx/sphinx-3.7.1/bin"
+ENV PATH "${PATH}:/opt/sphinx/sphinx-3.8.1/bin"
 RUN indexer -v
 
 # redirect logs to stdout

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You can use this image in `docker-compose`-powered app:
 ```yaml
 services:
   sphinx:
-    image: macbre/sphinxsearch:3.7.1
+    image: macbre/sphinxsearch:3.8.1
     ports:
     - "127.0.0.1:36307:36307" # bind to local interface only!
     volumes:
@@ -32,7 +32,7 @@ or you can provide your custom config file:
 ```yaml
 services:
   sphinx:
-    image: macbre/sphinxsearch:3.7.1
+    image: macbre/sphinxsearch:3.8.1
     environment:
     - SPHINX_CONFIG_FILE=/opt/sphinx/conf/my_custom_file.conf
     ports:
@@ -50,7 +50,24 @@ Read more at https://lukaszherok.com/post/view/9/Running%20SphinxSearch%20in%20P
 
 ## [Tags available](https://hub.docker.com/r/macbre/sphinxsearch/tags/)
 
-### `3.7.1`, `latest`
+### `3.8.1`, `latest`
+
+```
+Sphinx 3.8.1 (commit d25e0bb3)
+Copyright (c) 2001-2025, Andrew Aksyonoff
+Copyright (c) 2008-2016, Sphinx Technologies Inc (http://sphinxsearch.com)
+Built on: #1-Alpine SMP Thu, 18 May 2023 08:53:16 +0000
+Built with: GNU 10.3.1
+Build date: May 12 2025
+Build type: release
+Configure flags: cmake
+Compiled DB drivers: mysql-dynamic pgsql-dynamic odbc-dynamic
+Compiled features: libexpat libstemmer re2 faiss blis
+Versions: binlog_format v.22, index_format v.70, udf_api v.23
+Enabled dynamic drivers: mysql pgsql
+```
+
+### `3.7.1`
 
 ```
 Sphinx 3.7.1 (commit da9f8a4e7)


### PR DESCRIPTION
Blog post: https://sphinxsearch.com/blog/2025/05/14/sphinx-3-8-1-released/

```
Sphinx 3.8.1 (commit d25e0bb3)
Copyright (c) 2001-2025, Andrew Aksyonoff
Copyright (c) 2008-2016, Sphinx Technologies Inc (http://sphinxsearch.com/)
Built on: #1-Alpine SMP Thu, 18 May 2023 08:53:16 +0000
Built with: GNU 10.3.1
Build date: May 12 2025
Build type: release
Configure flags: cmake
Compiled DB drivers: mysql-dynamic pgsql-dynamic odbc-dynamic
Compiled features: libexpat libstemmer re2 faiss blis
Versions: binlog_format v.22, index_format v.70, udf_api v.23
Enabled dynamic drivers: mysql pgsql
```

And use the latest Alpine base image