### PR TITLE
Dockerfile: use the `minideb` as the base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,30 @@
 # Dockerfile for Sphinx SE
-# https://hub.docker.com/_/alpine/
-FROM --platform=linux/amd64 alpine:3.21
+# https://hub.docker.com/r/bitnami/minideb
+FROM bitnami/minideb:bookworm
 
 # https://sphinxsearch.com/blog/
-ENV SPHINX_VERSION 3.8.1-d25e0bb
+ENV SPHINX_VERSION=3.8.1-d25e0bb
 
 # install dependencies
-RUN apk add --no-cache mariadb-connector-c-dev \
-	postgresql-dev \
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends \
+	libgomp1 \
+	libmariadb3 libmariadb-dev \
+	libpq-dev \
 	wget
 
 # set up and expose directories
 RUN mkdir -pv /opt/sphinx/logs /opt/sphinx/indexes
 VOLUME /opt/sphinx/indexes
 
-# https://sphinxsearch.com/files/sphinx-3.8.1-d25e0bb-linux-amd64-musl.tar.gz
-RUN wget http://sphinxsearch.com/files/sphinx-${SPHINX_VERSION}-linux-amd64-musl.tar.gz -O /tmp/sphinxsearch.tar.gz \
+# https://sphinxsearch.com/files/sphinx-3.8.1-d25e0bb-linux-amd64-musl.tar.gz - Alpine
+# https://sphinxsearch.com/files/sphinx-3.8.1-d25e0bb-linux-amd64.tar.gz - Debian
+RUN wget http://sphinxsearch.com/files/sphinx-${SPHINX_VERSION}-linux-amd64.tar.gz -O /tmp/sphinxsearch.tar.gz \
 	&& cd /opt/sphinx && tar -xf /tmp/sphinxsearch.tar.gz \
 	&& rm /tmp/sphinxsearch.tar.gz
 
 # point to sphinx binaries
-ENV PATH "${PATH}:/opt/sphinx/sphinx-3.8.1/bin"
+ENV PATH="${PATH}:/opt/sphinx/sphinx-3.8.1/bin"
 RUN indexer -v
 
 # redirect logs to stdout
@@ -34,9 +38,9 @@ VOLUME /opt/sphinx/conf
 
 # allow custom config file to be passed
 ARG SPHINX_CONFIG_FILE=/opt/sphinx/conf/sphinx.conf
-ENV SPHINX_CONFIG_FILE ${SPHINX_CONFIG_FILE}
+ENV SPHINX_CONFIG_FILE=${SPHINX_CONFIG_FILE}
 
 # prepare a start script
 RUN echo "exec searchd --nodetach --config \${SPHINX_CONFIG_FILE}" > /opt/sphinx/start.sh
 
-CMD sh /opt/sphinx/start.sh
+CMD ["sh", "/opt/sphinx/start.sh"]


### PR DESCRIPTION
Fetch non-musl binaries. This change will allow use to build multi-arch images for both x64 and aarch64.

See #28

----

```
$ docker images
REPOSITORY                      TAG       IMAGE ID       CREATED         SIZE
macbre/sphinx                   latest    b1577b9eaa4b   2 minutes ago   337MB
ghcr.io/macbre/sphinxsearch     latest    1cff92fe61c1   3 days ago      796MB
ghcr.io/macbre/sphinxsearch     3.8.1     c0e5be0c58bf   3 days ago      796MB
```

```
$ docker run --rm -t macbre/sphinx ldd /opt/sphinx/sphinx-3.8.1/bin/indexer
	linux-vdso.so.1 (0x00007f25214d6000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f25203e4000)
	libgomp.so.1 => /lib/x86_64-linux-gnu/libgomp.so.1 (0x00007f252039c000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f2520397000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f25202b7000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f2520297000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f25200b4000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f25214d8000)

$ docker run --rm -t ghcr.io/macbre/sphinxsearch:3.8.1 ldd /opt/sphinx/sphinx-3.8.1/bin/indexer -v
	/lib/ld-musl-x86_64.so.1 (0x7f28b4295000)
	libgomp.so.1 => /usr/lib/libgomp.so.1 (0x7f28b346a000)
	libc.musl-x86_64.so.1 => /lib/ld-musl-x86_64.so.1 (0x7f28b4295000)
```

```
Sphinx 3.8.1 (commit d25e0bb3)
Copyright (c) 2001-2025, Andrew Aksyonoff
Copyright (c) 2008-2016, Sphinx Technologies Inc (http://sphinxsearch.com/)
Built on: #33~20.04.1-Ubuntu SMP Mon Feb 7 14:25:10 UTC 2022
Built with: GNU 10.5.0
Build date: May 12 2025
Build type: release
Configure flags: cmake
Compiled DB drivers: mysql-dynamic pgsql-dynamic odbc-dynamic
Compiled features: libexpat libstemmer re2 jemalloc faiss blis
Versions: binlog_format v.22, index_format v.70, udf_api v.23
Enabled dynamic drivers: mysql pgsql
```