### PR TITLE
Sphinx 3.9.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 FROM bitnami/minideb:bookworm
 
 # https://sphinxsearch.com/blog/
-ENV SPHINX_VERSION=3.8.1-d25e0bb
+ENV SPHINX_VERSION=3.9.1-141d2ea
 
 # install dependencies
 RUN apt-get update \
@@ -17,14 +17,14 @@ RUN apt-get update \
 RUN mkdir -pv /opt/sphinx/logs /opt/sphinx/indexes
 VOLUME /opt/sphinx/indexes
 
-# https://sphinxsearch.com/files/sphinx-3.8.1-d25e0bb-linux-amd64-musl.tar.gz - Alpine
-# https://sphinxsearch.com/files/sphinx-3.8.1-d25e0bb-linux-amd64.tar.gz - Debian
+# https://sphinxsearch.com/files/sphinx-3.9.1-141d2ea-linux-amd64-musl.tar.gz - Alpine
+# https://sphinxsearch.com/files/sphinx-3.9.1-141d2ea-linux-amd64.tar.gz - Debian
 RUN wget http://sphinxsearch.com/files/sphinx-${SPHINX_VERSION}-linux-amd64.tar.gz -O /tmp/sphinxsearch.tar.gz \
 	&& cd /opt/sphinx && tar -xf /tmp/sphinxsearch.tar.gz \
 	&& rm /tmp/sphinxsearch.tar.gz
 
 # point to sphinx binaries
-ENV PATH="${PATH}:/opt/sphinx/sphinx-3.8.1/bin"
+ENV PATH="${PATH}:/opt/sphinx/sphinx-3.9.1/bin"
 RUN indexer -v
 
 # redirect logs to stdout

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You can use this image in `docker-compose`-powered app:
 ```yaml
 services:
   sphinx:
-    image: macbre/sphinxsearch:3.8.1
+    image: macbre/sphinxsearch:3.9.1
     ports:
     - "127.0.0.1:36307:36307" # bind to local interface only!
     volumes:
@@ -32,7 +32,7 @@ or you can provide your custom config file:
 ```yaml
 services:
   sphinx:
-    image: macbre/sphinxsearch:3.8.1
+    image: macbre/sphinxsearch:3.9.1
     environment:
     - SPHINX_CONFIG_FILE=/opt/sphinx/conf/my_custom_file.conf
     ports:
@@ -50,7 +50,25 @@ Read more at https://lukaszherok.com/post/view/9/Running%20SphinxSearch%20in%20P
 
 ## [Tags available](https://hub.docker.com/r/macbre/sphinxsearch/tags/)
 
-### `3.8.1`, `latest`
+### `3.9.1`
+
+```
+Sphinx 3.9.1 (commit 141d2ea31)
+Copyright (c) 2001-2025, Andrew Aksyonoff
+Copyright (c) 2008-2016, Sphinx Technologies Inc (http://sphinxsearch.com)
+
+Built on: #25-Ubuntu SMP Wed Mar 30 15:54:22 UTC 2022
+Built with: GNU 11.2.0
+Build date: Dec 19 2025
+Build type: release
+Configure flags: cmake
+Compiled DB drivers: mysql-dynamic pgsql-dynamic odbc-dynamic
+Compiled features: libexpat libstemmer re2 jemalloc faiss blis
+Versions: binlog_format v.26, index_format v.72, udf_api v.24
+Enabled dynamic drivers: mysql pgsql
+```
+
+### `3.8.1`
 
 ```
 Sphinx 3.8.1 (commit d25e0bb3)


### PR DESCRIPTION
https://sphinxsearch.com/blog/2025/12/19/sphinx-3-9-1-released/

https://sphinxsearch.com/docs/sphinx3.html#version-3.9.1-18-dec-2025